### PR TITLE
remove lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A Neovim client for [VsCoq 2 `vscoqtop`](https://github.com/coq-community/vscoq)
 ## Setup
 ### [vim-plug](https://github.com/junegunn/vim-plug)
 ```vim
-Plug 'neovim/nvim-lspconfig'
 Plug 'whonore/Coqtail' " for ftdetect, syntax, basic ftplugin, etc
 Plug 'tomtomjhj/vscoq.nvim'
 
@@ -35,7 +34,6 @@ lua require'vscoq'.setup()
   'tomtomjhj/vscoq.nvim',
   filetypes = 'coq',
   dependecies = {
-    'neovim/nvim-lspconfig',
     'whonore/Coqtail',
   },
   opts = {
@@ -69,9 +67,6 @@ lua require'vscoq'.setup()
         * `:VsCoq goals`: Show the normal goals and messages (default).
     * etc
         * `:VsCoq jumpToEnd`: Jump to the end of the checked region.
-* [Commands from nvim-lspconfig](https://github.com/neovim/nvim-lspconfig#commands)
-  work as expected.
-  For example, run `:LspRestart` to restart `vscoqtop`.
 
 ## Configurations
 The `setup()` function takes a table with the followings keys:

--- a/lua/vscoq/init.lua
+++ b/lua/vscoq/init.lua
@@ -84,6 +84,12 @@ local function proofView_notification_handler(_, result, ctx, _)
   M.clients[ctx.client_id]:proofView(result)
 end
 
+local vscoqtop_config = {
+  cmd = { 'vscoqtop' },
+  filetypes = { 'coq' },
+  root_markers = { '_CoqProject', '.git' },
+}
+
 -- TODO: don't use custom setup and use lspconfig's add_hook_before?
 ---@param opts { vscoq?: table<string,any>, lsp?: table<string,any> }
 function M.setup(opts)
@@ -108,7 +114,8 @@ function M.setup(opts)
     "[vscoq.nvim] settings must be passed via 'vscoq' field"
   )
   opts.lsp.init_options = opts.vscoq:to_lsp_options()
-  require('lspconfig').vscoqtop.setup(opts.lsp)
+  vim.lsp.config('vscoqtop', vim.tbl_deep_extend('force', vscoqtop_config, opts.lsp))
+  vim.lsp.enable('vscoqtop')
 end
 
 return M


### PR DESCRIPTION
In vim 0.11 lsp, is built in, vscoq.nvim plugin no more require lsp-config.